### PR TITLE
Feat add retry logic

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -22,6 +22,12 @@ plugins:
       value: '2024-02-15'
     - name: start_date
       value: '2000-01-01'
+    - name: max_retries
+      value: 5
+    - name: backoff_factor
+      value: 2
+    - name: retry_statuses
+      value: [400]
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from urllib.parse import parse_qsl
 
 from singer_sdk.authenticators import APIKeyAuthenticator
-from singer_sdk.exceptions import FatalAPIError, RetriableAPIError
+from singer_sdk.exceptions import RetriableAPIError
 from singer_sdk.pagination import BaseHATEOASPaginator
 from singer_sdk.streams import RESTStream
 
@@ -85,7 +85,6 @@ class KlaviyoStream(RESTStream):
                 f"for URL {response.url}"
             )
         super().validate_response(response)
-
 
     def backoff_max_tries(self) -> int:
         return int(self.config.get("max_retries", 3))

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from urllib.parse import parse_qsl
 
 from singer_sdk.authenticators import APIKeyAuthenticator
+from singer_sdk.exceptions import FatalAPIError
 from singer_sdk.pagination import BaseHATEOASPaginator
 from singer_sdk.streams import RESTStream
 
@@ -75,6 +76,11 @@ class KlaviyoStream(RESTStream):
         if "revision" in self.config:
             headers["revision"] = self.config.get("revision")
         return headers
+
+    @property
+    def backoff_exceptions(self) -> tuple[type[BaseException], ...]:
+        """Define exceptions that trigger backoff & retries."""
+        return (*super().backoff_exceptions, FatalAPIError)
 
     def backoff_max_tries(self) -> int:
         return int(self.config.get("max_retries", 3))

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -44,7 +44,7 @@ class KlaviyoPaginator(BaseHATEOASPaginator):
 class KlaviyoStream(RESTStream):
     """Klaviyo stream class."""
 
-    url_base = "https://a.klaviyo.com/api"
+    url_base = "https://httpbin.org/status/400"
     records_jsonpath = "$[data][*]"
     max_page_size: int | None = None
 

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -45,7 +45,7 @@ class KlaviyoPaginator(BaseHATEOASPaginator):
 class KlaviyoStream(RESTStream):
     """Klaviyo stream class."""
 
-    url_base = "https://httpbin.org/status/400"
+    url_base = "https://a.klaviyo.com/api"
     records_jsonpath = "$[data][*]"
     max_page_size: int | None = None
 

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -77,13 +77,13 @@ class KlaviyoStream(RESTStream):
             headers["revision"] = self.config.get("revision")
         return headers
 
-    def validate_response(self, response):
-        """Raise only retryable errors as retryable exceptions."""
+    def validate_response(self, response: requests.Response) -> None:
         if not response.ok and response.status_code in self.config.get("retry_statuses", {}):
-            raise RetriableAPIError(
+            error_message = (
                 f"Retryable error {response.status_code} {response.reason} "
                 f"for URL {response.url}"
             )
+            raise RetriableAPIError(error_message)
         super().validate_response(response)
 
     def backoff_max_tries(self) -> int:

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -9,6 +9,7 @@ from urllib.parse import parse_qsl
 
 from singer_sdk.authenticators import APIKeyAuthenticator
 from singer_sdk.pagination import BaseHATEOASPaginator
+from singer_sdk.requests import BaseRequester
 from singer_sdk.streams import RESTStream
 
 if t.TYPE_CHECKING:
@@ -75,6 +76,9 @@ class KlaviyoStream(RESTStream):
         if "revision" in self.config:
             headers["revision"] = self.config.get("revision")
         return headers
+
+    def get_requester(self) -> BaseRequester:
+        return super().get_requester()
 
     def get_new_paginator(self) -> BaseHATEOASPaginator:
         return KlaviyoPaginator()

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -79,7 +79,6 @@ class KlaviyoStream(RESTStream):
 
     def validate_response(self, response):
         """Raise only retryable errors as retryable exceptions."""
-        super().validate_response(response)
 
         if not response.ok:
             if response.status_code in {429, 500, 502, 503, 504}:
@@ -87,7 +86,7 @@ class KlaviyoStream(RESTStream):
                     f"Retryable error {response.status_code} {response.reason} "
                     f"for URL {response.url}"
                 )
-            raise FatalAPIError(f"Fatal error {response.status_code} for URL {response.url}")
+        super().validate_response(response)
 
 
     def backoff_max_tries(self) -> int:

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -93,7 +93,7 @@ class KlaviyoStream(RESTStream):
         backoff_factor = float(self.config.get("backoff_factor", 2))
         max_tries = self.backoff_max_tries()
         for attempt in range(max_tries):
-            yield backoff_factor * (2 ** attempt)
+            yield backoff_factor * (2**attempt)
 
     def get_new_paginator(self) -> BaseHATEOASPaginator:
         return KlaviyoPaginator()


### PR DESCRIPTION
This PR leverages default Meltano retry methods to allow retrying specific error codes, and can be configured in meltano.yml as such:
```
    config:
      max_retries: 5
      backoff_factor: 2
      retry_statuses: [400]
```