### PR TITLE
feat: add filtering logic

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -22,12 +22,6 @@ plugins:
       value: '2024-02-15'
     - name: start_date
       value: '2000-01-01'
-    - name: max_retries
-      value: 5
-    - name: backoff_factor
-      value: 2
-    - name: retry_statuses
-      value: [400]
   loaders:
   - name: target-jsonl
     variant: andyh1203


### PR DESCRIPTION
We observed rare case instances of Klaviyo API returning events way in the future (events API).
Those events will update the state to the future as well, meaning that every future call will fail because a `greater-than` filter in the API call isn't allowed.

This PR is a suggestion that would eliminate the issue by filtering out future events.
Feel free to suggest alternative approaches.



Example of a payload queried on 2024-04-12. Note that datetime (which is the Event's stream replication key) is 2025-04-21:

```
 {
            "type": "event",
            "id": "xxx",
            "attributes": {
                "timestamp": 1745246922,
                "event_properties": {
                    "utm_medium": "xxx",
                    "os": "Windows",
                    "initial_page_path": "/",
                    "browser": "Chrome",
                    "page": "xxx",
                    "utm_source": "xxx",
                    "rfsn": "xxx",
                    "$event_id": "1745246922"
                },
                "datetime": "2025-04-21T14:48:42+00:00",
                "uuid": "xxx"
            },
            "relationships": {
                "profile": {
                    "data": {
                        "type": "profile",
                        "id": "xxx"
                    },
                    "links": {
                        "self": "https://a.klaviyo.com/api/events/xxx/relationships/profile/",
                        "related": "https://a.klaviyo.com/api/events/xxx/profile/"
                    }
                },
                "metric": {
                    "data": {
                        "type": "metric",
                        "id": "xxx"
                    },
                    "links": {
                        "self": "https://a.klaviyo.com/api/events/xxx/relationships/metric/",
                        "related": "https://a.klaviyo.com/api/events/xxx/metric/"
                    }
                }
            },
            "links": {
                "self": "https://a.klaviyo.com/api/events/xxx/"
            }
        }
    ],
    "links": {
        "self": "https://a.klaviyo.com/api/events?sort=datetime&filter=greater-than%28datetime%2C2025-04-14+02%3A39%3A06%2B00%3A00%29",
        "next": null,
        "prev": null
    }
```